### PR TITLE
append m-code arguments to the system command

### DIFF
--- a/src/dsf/execOnMcode.py
+++ b/src/dsf/execOnMcode.py
@@ -58,7 +58,13 @@ def __do_action_for_code(intercept_connection, actions, code):
             return
     # TODO: use user
     try:
-        out = subprocess.run(action.cmd_command,
+        action_command = str(action.cmd_command)
+
+        # if the m-code was passed with an argument, append that argument to the system command
+        if len(str(code).split(" ", 1)) == 2:
+            action_command = action_command + " " + str(code).split(" " , 1)[1].strip('\"')
+
+        out = subprocess.run(action_command,
                                 shell=True,
                                 timeout=action.cmd_timeout,
                                 capture_output=True,


### PR DESCRIPTION
I was looking for a simple way to append arguments from the m-code command to the system command. In addition to adding the arguments to the end of cmd_command, if cmd_command is empty, arbitrary commands can be ran on the system. I'm not sure if this of any value to anybody else, but the increased flexibility has been extremely useful to me and I wanted to share. 